### PR TITLE
Implement namespace isolation in tiered policy

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -28,8 +28,17 @@ WATCH_URLS = {RESOURCE_TYPE_POD: "%s/api/v1/watch/pods",
 # Annotation to look for network-isolation on namespaces.
 NS_POLICY_ANNOTATION = "net.alpha.kubernetes.io/network-isolation"
 
-# Tier name to use for policies.
+# Tier name /order to use for policies.
 NET_POL_TIER_NAME = "k8s-network-policy"
+NET_POL_TIER_ORDER = 100
+
+# The priority assigned to network policies created by the agent.
+# Lower order -> higher priority.
+NET_POL_ORDER = 1000
+
+# The priority assigned to namespace policies.
+# This policy is hit when no NetworkPolicy objects match.
+NET_POL_NS_ORDER = 2000
 
 # Environment variables for getting the Kubernetes API.
 K8S_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"

--- a/handlers/namespace.py
+++ b/handlers/namespace.py
@@ -48,6 +48,15 @@ def add_update_namespace(namespace):
     # update it if it already exists.
     client.create_profile(profile_name, rules, labels)
 
+    # Create / update the tiered policy object for this namespace.
+    selector = "%s == '%s'" % (K8S_NAMESPACE_LABEL, namespace_name)
+    name = "calico-%s" % profile_name
+    client.create_policy(NET_POL_TIER_NAME,
+                         name,
+                         selector,
+                         order=NET_POL_NS_ORDER,
+                         rules=rules)
+
     _log.debug("Created/updated profile for namespace %s", namespace_name)
 
 

--- a/handlers/network_policy.py
+++ b/handlers/network_policy.py
@@ -51,8 +51,11 @@ def add_update_network_policy(policy):
                       outbound_rules=[Rule(action="allow")])
 
         # Create the network policy using the calculated selector and rules.
-        client.create_policy(NET_POL_TIER_NAME, name,
-                             selector, order=10, rules=rules)
+        client.create_policy(NET_POL_TIER_NAME,
+                             name,
+                             selector,
+                             order=NET_POL_ORDER,
+                             rules=rules)
         _log.debug("Updated policy '%s' for NetworkPolicy", name)
 
 

--- a/policy_agent.py
+++ b/policy_agent.py
@@ -134,7 +134,7 @@ class PolicyAgent(object):
             self._start_leader_thread()
 
         # Ensure the tier exists.
-        metadata = {"order": 50}
+        metadata = {"order": NET_POL_TIER_ORDER}
         self._client.set_policy_tier_metadata(NET_POL_TIER_NAME, metadata)
 
         # Read initial state from Kubernetes API.


### PR DESCRIPTION
Create a tiered policy object to do namespace isolation.

This allows us to match the desired API behavior of "allow everything when network-isolation=no" even when policy objects have been defined.

Fixes #14 