### PR TITLE
Stop using per-namespace Policies, send to next-tier.

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -36,9 +36,10 @@ NET_POL_TIER_ORDER = 1000
 # Lower order -> higher priority.
 NET_POL_ORDER = 1000
 
-# The priority assigned to namespace policies.
-# This policy is hit when no NetworkPolicy objects match.
-NET_POL_NS_ORDER = 2000
+# The priority assigned to the backstop policy that applies
+# to traffic which doesn't match one of the configured policies
+# in the NET_POL_TIER_NAME tier.
+NET_POL_BACKSTOP_ORDER = 2000
 
 # Environment variables for getting the Kubernetes API.
 K8S_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"

--- a/handlers/namespace.py
+++ b/handlers/namespace.py
@@ -63,14 +63,14 @@ def add_update_namespace(namespace):
     # update it if it already exists.
     client.create_profile(profile_name, rules, labels)
 
-    # Create / update the tiered policy object for this namespace.
-    selector = "%s == '%s'" % (K8S_NAMESPACE_LABEL, namespace_name)
+    # Delete any per-namespace policy.  Older versions of the policy-controller
+    # used to install these, but they're not relevant any more.
     name = "calico-%s" % profile_name
-    client.create_policy(NET_POL_TIER_NAME,
-                         name,
-                         selector,
-                         order=NET_POL_NS_ORDER,
-                         rules=rules)
+    try:
+        client.remove_policy(NET_POL_TIER_NAME, name)
+    except KeyError:
+        # Policy doesn't exist, we're all good.
+        pass
 
     _log.debug("Created/updated profile for namespace %s", namespace_name)
 


### PR DESCRIPTION
This allows users to configure the default behavior for a namespace using `calicoctl profile` commands, as well as install their own policies out of band of Kubernetes in a tier after the k8s policy tier.