### PR TITLE
Change tier name from k8s-network-policy to default, better documentation for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.tar
 *.created
 *.coverage
+.idea/

--- a/configuration.md
+++ b/configuration.md
@@ -58,4 +58,6 @@ the root directory of the container. This can be done by mounting a file from th
 
 ### Other configuration
 
+* `LOG_LEVEL`: Supports the standard Python log levels. e.g. `LOG_LEVEL=debug`, defaults to `info`
+
 More information on leader election can be found in the [kubernetes/contrib](https://github.com/kubernetes/contrib/tree/master/election#simple-leader-election-with-kubernetes-and-docker) repository.

--- a/constants.py
+++ b/constants.py
@@ -29,7 +29,6 @@ WATCH_URLS = {RESOURCE_TYPE_POD: "%s/api/v1/watch/pods",
 NS_POLICY_ANNOTATION = "net.beta.kubernetes.io/network-policy"
 
 # Tier name /order to use for policies.
-NET_POL_TIER_NAME = "k8s-network-policy"
 NET_POL_TIER_ORDER = 1000
 
 # The priority assigned to network policies created by the controller.

--- a/handlers/namespace.py
+++ b/handlers/namespace.py
@@ -63,15 +63,6 @@ def add_update_namespace(namespace):
     # update it if it already exists.
     client.create_profile(profile_name, rules, labels)
 
-    # Delete any per-namespace policy.  Older versions of the policy-controller
-    # used to install these, but they're not relevant any more.
-    name = "calico-%s" % profile_name
-    try:
-        client.remove_policy(NET_POL_TIER_NAME, name)
-    except KeyError:
-        # Policy doesn't exist, we're all good.
-        pass
-
     _log.debug("Created/updated profile for namespace %s", namespace_name)
 
 
@@ -80,7 +71,7 @@ def delete_namespace(namespace):
     Takes a deleted namespace and removes the corresponding
     configuration from the Calico datastore.
     """
-    # Delete the Calico policy which represnets this namespace.
+    # Delete the Calico policy which represents this namespace.
     namespace_name = namespace["metadata"]["name"]
     profile_name = NS_PROFILE_FMT % namespace_name
     _log.debug("Deleting namespace profile: %s", profile_name)

--- a/handlers/network_policy.py
+++ b/handlers/network_policy.py
@@ -37,7 +37,7 @@ def add_update_network_policy(policy):
                       outbound_rules=[Rule(action="allow")])
 
         # Create the network policy using the calculated selector and rules.
-        client.create_policy(NET_POL_TIER_NAME,
+        client.create_policy("default",
                              name,
                              selector,
                              order=NET_POL_ORDER,
@@ -57,6 +57,6 @@ def delete_network_policy(policy):
 
     # Delete the corresponding Calico policy
     try:
-        client.remove_policy(NET_POL_TIER_NAME, name)
+        client.remove_policy("default", name)
     except KeyError:
         _log.info("Unable to find policy '%s' - already deleted", name)


### PR DESCRIPTION
- Changed tier name to default Fixes #52 
- Added attempt to remove old tier name from etcd
- Changed all references to the old tier name to the new one ('default')
- updated the docs to show how to increase the log level
- minor pep8 and typo fixes