### PR TITLE
Use alpine 3.4 which supports dns search domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.3
+FROM alpine:3.4
 
 ADD *.py /code/
 ADD handlers /code/handlers


### PR DESCRIPTION
Fixes #23 

Included in the [alpine 3.4 release notes](https://alpinelinux.org/posts/Alpine-3.4.0-released.html):

>- Support for DNS search domains in /etc/resolv.conf