### PR TITLE
[WIP] Add support for egress policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.4
+FROM alpine:3.5
 
 ADD *.py /code/
 ADD handlers /code/handlers

--- a/constants.py
+++ b/constants.py
@@ -25,6 +25,7 @@ CA_CERT_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
 # Resource types.
 RESOURCE_TYPE_NETWORK_POLICY = "NetworkPolicy"
+RESOURCE_TYPE_EGRESS_POLICY = "Egresspolicy"
 RESOURCE_TYPE_POD = "Pod"
 RESOURCE_TYPE_NAMESPACE = "Namespace"
 
@@ -33,13 +34,21 @@ BETA_API = "%s/apis/extensions/v1beta1"
 NET_POLICY_PATH = BETA_API + "/networkpolicies"
 NET_POLICY_WATCH_PATH = BETA_API + "/watch/networkpolicies"
 
+# API paths to EgressPolicy objects.
+THIRDPARTY_API = "%s/apis/projectcalico.org/v1"
+EGRESS_POLICY_PATH = THIRDPARTY_API + "/egresspolicies"
+EGRESS_POLICY_WATCH_PATH = THIRDPARTY_API + "/watch/egresspolicies"
+
 # Mapping of resource to api URL.
 GET_URLS = {RESOURCE_TYPE_POD: "%s/api/v1/pods",
             RESOURCE_TYPE_NAMESPACE: "%s/api/v1/namespaces",
-            RESOURCE_TYPE_NETWORK_POLICY: NET_POLICY_PATH}
+            RESOURCE_TYPE_NETWORK_POLICY: NET_POLICY_PATH,
+            RESOURCE_TYPE_EGRESS_POLICY: EGRESS_POLICY_PATH}
+
 WATCH_URLS = {RESOURCE_TYPE_POD: "%s/api/v1/watch/pods",
               RESOURCE_TYPE_NAMESPACE: "%s/api/v1/watch/namespaces",
-              RESOURCE_TYPE_NETWORK_POLICY: NET_POLICY_WATCH_PATH}
+              RESOURCE_TYPE_NETWORK_POLICY: NET_POLICY_WATCH_PATH,
+              RESOURCE_TYPE_EGRESS_POLICY: EGRESS_POLICY_WATCH_PATH}
 
 # Annotation to look for network-isolation on namespaces.
 NS_POLICY_ANNOTATION = "net.beta.kubernetes.io/network-policy"

--- a/controller.py
+++ b/controller.py
@@ -94,6 +94,14 @@ class Controller(object):
         self.add_handler(RESOURCE_TYPE_NETWORK_POLICY, TYPE_DELETED,
                          delete_network_policy)
 
+        # Handlers for NetworkPolicy events.
+        self.add_handler(RESOURCE_TYPE_EGRESS_POLICY, TYPE_ADDED,
+                         add_update_network_policy)
+        self.add_handler(RESOURCE_TYPE_EGRESS_POLICY, TYPE_MODIFIED,
+                         add_update_network_policy)
+        self.add_handler(RESOURCE_TYPE_EGRESS_POLICY, TYPE_DELETED,
+                         delete_network_policy)
+
         # Handlers for Namespace events.
         self.add_handler(RESOURCE_TYPE_NAMESPACE, TYPE_ADDED,
                          add_update_namespace)
@@ -234,6 +242,7 @@ class Controller(object):
         API resource.
         """
         resources = [RESOURCE_TYPE_NETWORK_POLICY,
+                     RESOURCE_TYPE_EGRESS_POLICY,
                      RESOURCE_TYPE_NAMESPACE,
                      RESOURCE_TYPE_POD]
 

--- a/examples/egress/README.md
+++ b/examples/egress/README.md
@@ -1,0 +1,12 @@
+##### WIP #####
+
+This examples show how to create Egress Rules:
+
+1) Create a third party resource called egresspolicy, with the following command:
+
+``kubectl create -f egress-resouce-yaml``
+
+2) Create some Egress Policy (like the Network Policy), as the following example file:
+
+``kubectl create -f egress-policy.yaml``
+

--- a/examples/egress/egress-policy.yaml
+++ b/examples/egress/egress-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: "projectcalico.org/v1"
+kind: Egresspolicy
+metadata:
+  name: test-egress
+  namespace: app1
+spec:
+  podSelector:
+    matchLabels:
+      run: nginx 
+  egress:
+  - ports:
+    - protocol: icmp
+    

--- a/examples/egress/egress-resource.yaml
+++ b/examples/egress/egress-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: egresspolicy.projectcalico.org
+description: "Egress Policy"
+versions:
+- name: v1

--- a/handlers/network_policy.py
+++ b/handlers/network_policy.py
@@ -40,6 +40,7 @@ def add_update_network_policy(policy):
         parser = PolicyParser(policy)
         selector = parser.calculate_pod_selector()
         inbound_rules = parser.calculate_inbound_rules()
+        outbound_rules = parser.calculate_outbound_rules()
     except Exception:
         # If the Policy is malformed, log the error and kill the controller.
         # Kubernetes will restart us.
@@ -48,7 +49,7 @@ def add_update_network_policy(policy):
         os.exit(1)
     else:
         rules = Rules(inbound_rules=inbound_rules,
-                      outbound_rules=[Rule(action="allow")])
+                      outbound_rules=outbound_rules)
 
         # Create the network policy using the calculated selector and rules.
         client.create_policy("default",


### PR DESCRIPTION
This is a WIP and maybe a PoC, so we can see if this is applicable.

While Kubernetes Network Policy doesn't support Egress Policies (and Egress Isolation) this PR adds support for Egress Policies in Calico (with Kubernetes), using a Third Party Resource that creates an 'EgressPolicy' Object. The files that creates those resources are in 'examples/egress'

Basically, it uses almost the same logic from NetworkPolicy. Also it adds support for Egress DefaultDeny isolation.

This is related to issue #95 

TODO (for now):

* [ ] While doing this PR, I've faced a error that made the controller panic (need to be debugged also). This happens when the Selector (inside Spec itself) is namespaceSelector and not podSelector
* [ ] Change the code to support also IP Addresses as a destiny, and not only Kubernetes Objects
* [ ] Improve the Docs

