### PR TITLE
Update system testing for API server 1.6.4 (fixes #97)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ st: docker-image run-etcd run-k8s-apiserver
 	$(MAKE) stop-k8s-apiserver stop-etcd
 
 GET_CONTAINER_IP := docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'
-K8S_VERSION=1.5.3
+K8S_VERSION=1.6.4
 .PHONY: run-k8s-apiserver stop-k8s-apiserver run-etcd stop-etcd
 run-k8s-apiserver: stop-k8s-apiserver
 	ETCD_IP=`$(GET_CONTAINER_IP) st-etcd` && \
@@ -29,7 +29,8 @@ run-k8s-apiserver: stop-k8s-apiserver
 	  --name st-apiserver \
 	gcr.io/google_containers/hyperkube-amd64:v$(K8S_VERSION) \
 		  /hyperkube apiserver --etcd-servers=http://$${ETCD_IP}:2379 \
-		  --service-cluster-ip-range=10.101.0.0/16 -v=10
+		  --service-cluster-ip-range=10.101.0.0/16 -v=10 \
+		  --authorization-mode=RBAC
 
 stop-k8s-apiserver:
 	@-docker rm -f st-apiserver


### PR DESCRIPTION
- This means we have to add RBAC for the anonymous user.  For a more
  detailed explanation see
  https://github.com/projectcalico/felix/commit/6e9f6d8e8a6b8ded7dec0dccba502bdd9891f06f.

- Also fix mistaken use of a hardcoded IP address for the API
  server (even though we also had the correct, dynamically determined IP
  address to hand).
