### PR TITLE
Modify controller to support GA NetworkPolicy

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -41,19 +41,12 @@ WATCH_URLS = {RESOURCE_TYPE_POD: "%s/api/v1/watch/pods",
               RESOURCE_TYPE_NAMESPACE: "%s/api/v1/watch/namespaces",
               RESOURCE_TYPE_NETWORK_POLICY: NET_POLICY_WATCH_PATH}
 
-# Annotation to look for network-isolation on namespaces.
-NS_POLICY_ANNOTATION = "net.beta.kubernetes.io/network-policy"
-
 # Tier name /order to use for policies.
 NET_POL_TIER_ORDER = 1000
 
 # The priority assigned to network policies created by the controller.
 # Lower order -> higher priority.
 NET_POL_ORDER = 1000
-
-# The priority assigned to the backstop policy that applies
-# to traffic which doesn't match one of the configured policies.
-NET_POL_NO_MATCH_ORDER = int(os.environ.get("NO_MATCH_ORDER", 2000))
 
 # Environment variables for getting the Kubernetes API.
 K8S_SERVICE_PORT = "KUBERNETES_SERVICE_PORT"

--- a/handlers/namespace.py
+++ b/handlers/namespace.py
@@ -24,47 +24,17 @@ client = DatastoreClient()
 
 def add_update_namespace(namespace):
     """
-    Configures the necessary policy in Calico for this
-    namespace.  Uses the `net.alpha.kubernetes.io/network-isolation`
-    annotation.
+    Configures a Profile for the given Kubernetes namespace.
     """
     namespace_name = namespace["metadata"]["name"]
     _log.debug("Adding/updating namespace: %s", namespace_name)
 
-    # Determine the type of network-isolation specified by this namespace.
-    # This defaults to no isolation.
-    annotations = namespace["metadata"].get("annotations", {})
-    _log.debug("Namespace %s has annotations: %s", namespace_name, annotations)
-    policy_annotation = annotations.get(NS_POLICY_ANNOTATION, "{}")
-    try:
-        policy_annotation = json.loads(policy_annotation)
-    except ValueError, TypeError:
-        _log.exception("Failed to parse namespace annotations: %s", annotations)
-        return
-
-    # Parsed the annotation - get data.  Might not be a dict, so be careful
-    # to catch an AttributeError if it has no get() method.
-    try:
-        ingress_isolation = policy_annotation.get("ingress", {}).get("isolation", "")
-    except AttributeError:
-        _log.exception("Invalid namespace annotation: %s", policy_annotation)
-        return
-
-    isolate_ns = ingress_isolation == "DefaultDeny"
-    _log.debug("Namespace %s has %s.  Isolate=%s",
-            namespace_name, ingress_isolation, isolate_ns)
-
     # Determine the profile name to create.
     profile_name = NS_PROFILE_FMT % namespace_name
 
-    # Determine the rules to use.
-    outbound_rules = [Rule(action="allow")]
-    if isolate_ns:
-        inbound_rules = [Rule(action="deny")]
-    else:
-        inbound_rules = [Rule(action="allow")]
-    rules = Rules(inbound_rules=inbound_rules,
-                  outbound_rules=outbound_rules)
+    # Build the rules to use.
+    rules = Rules(inbound_rules=[Rule(action="allow")],
+                  outbound_rules=[Rule(action="allow")])
 
     # Assign labels to the profile.  We modify the keys to use
     # a special prefix to indicate that these labels are inherited

--- a/tests/system/apiserver-reconnection.sh
+++ b/tests/system/apiserver-reconnection.sh
@@ -32,6 +32,9 @@ docker run --detach --name=calico-policy-controller \
        calico/kube-policy-controller
 sleep 2
 
+# Create a trap which emits policy controller logs on failure.
+trap "echo 'Test failed - printing logs:'; docker logs calico-policy-controller" ERR
+
 # Create a namespace.
 NS_NAME=chocolate
 create_namespace ${NS_NAME}


### PR DESCRIPTION
## Description

Updates the policy controller to support the v1 NetworkPolicy API, and removes support for the v1beta1 NetworkPolicy API.

The controller still watches the extensions endpoint, but will enforce policies created through either the `extensions/v1beta1` or `networking.k8s.io/v1` API in the same way, using the behavior defined in the v1 specification.

Fixes #103 

## Todos
- [x] Tests (No new tests)
- [x] Documentation (see: https://github.com/projectcalico/calico/pull/914)
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico now implements the networking.k8s.io/NetworkPolicy API semantics [as defined by Kubernetes](https://github.com/kubernetes/kubernetes/pull/39164#issue-197243974) when using the etcd datastore

- **Note:** This represents a change in how existing Kubernetes NetworkPolicies are enforced by Calico. To maintain existing behavior when upgrading, follow these steps: - In Namespaces that previously did not have the “DefaultDeny” annotation, you should delete any existing NetworkPolicy objects. - In Namespaces that previously did have the “DefaultDeny” annotation, you can create the equivalent semantics by creating a NetworkPolicy that selects all pods but does not allow any traffic.
```
