### PR TITLE
Fix in pod to workloadEndpoint conversion code

### DIFF
--- a/pkg/converter/pod_converter.go
+++ b/pkg/converter/pod_converter.go
@@ -30,7 +30,7 @@ func (p *podConverter) Convert(k8sObj interface{}) (interface{}, error) {
 	if pod.ObjectMeta.Labels != nil {
 		endpoint.Metadata.Labels = pod.ObjectMeta.Labels
 	} else {
-		endpoint.Metadata.Labels = make(map[string]string)
+		endpoint.Metadata.Labels = map[string]string{}
 	}
 
 	// Add a special label for the Kubernetes namespace.  This is used

--- a/pkg/converter/pod_converter.go
+++ b/pkg/converter/pod_converter.go
@@ -27,7 +27,11 @@ func (p *podConverter) Convert(k8sObj interface{}) (interface{}, error) {
 	endpoint := api.NewWorkloadEndpoint()
 
 	endpoint.Metadata.Workload = fmt.Sprintf("%s.%s", pod.Namespace, pod.Name)
-	endpoint.Metadata.Labels = pod.ObjectMeta.Labels
+	if pod.ObjectMeta.Labels != nil {
+		endpoint.Metadata.Labels = pod.ObjectMeta.Labels
+	} else {
+		endpoint.Metadata.Labels = make(map[string]string)
+	}
 
 	// Add a special label for the Kubernetes namespace.  This is used
 	// by selector-based policies to select all pods in a given namespace.


### PR DESCRIPTION
## Description
If no labels are provided in k8s pod then create an empty map and assign default label to workloadEndpoint.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
