### PR TITLE
Use libcalico to convert workload endpoints.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4ba91715a30d4b443b34d326342b502cb0bfe0bea363303090e7d284d3b82754
-updated: 2017-09-11T18:23:11.396661468-07:00
+hash: 59d162818df2f76a20ea332cf0f5298635b23594f03c2896d444f86c27f40ae4
+updated: 2017-09-13T12:06:03.847071609-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -108,7 +108,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 52ada4f5d18767b02a67eaa7af80bbbcf156de84
+  version: a3291af5e19321a381b4ee9c2828c8a179c27bec
   subpackages:
   - lib/api
   - lib/api/unversioned

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,4 +29,4 @@ import:
   - tools/cache
   - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: 52ada4f5d18767b02a67eaa7af80bbbcf156de84
+  version: a3291af5e19321a381b4ee9c2828c8a179c27bec


### PR DESCRIPTION
## Description

Use libcalico to convert workload endpoints so that we share the same generate code as used in KDD.