### PR TITLE
Adding support for ppc64le builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@
 FROM alpine:3.5
 MAINTAINER Casey Davenport <casey@tigera.io> 
 
-ADD dist/kube-policy-controller /usr/bin
+ADD dist/kube-policy-controller-linux-amd64 /usr/bin/kube-policy-controller
 ENTRYPOINT ["/usr/bin/kube-policy-controller"]

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,0 +1,18 @@
+# Copyright 2015-2017 Tigera, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM ppc64le/alpine:3.6
+MAINTAINER Casey Davenport <casey@tigera.io> 
+
+ADD dist/kube-policy-controller /usr/bin
+ENTRYPOINT ["/usr/bin/kube-policy-controller"]

--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -14,5 +14,5 @@
 FROM ppc64le/alpine:3.6
 MAINTAINER Casey Davenport <casey@tigera.io> 
 
-ADD dist/kube-policy-controller /usr/bin
+ADD dist/kube-policy-controller-linux-ppc64le /usr/bin/kube-policy-controller
 ENTRYPOINT ["/usr/bin/kube-policy-controller"]

--- a/tests/system/apiserver-reconnection.sh
+++ b/tests/system/apiserver-reconnection.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+ARCHTAG=$1
+
 function get_container_ip {
     docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $1
 }
@@ -50,7 +52,7 @@ docker run --detach --name=calico-policy-controller \
 	-e KUBECONFIG=/st-kubeconfig.yaml \
 	-e ENABLED_CONTROLLERS="endpoint,profile,policy" \
 	-e LOG_LEVEL="debug" \
-	calico/kube-policy-controller
+	calico/kube-policy-controller$ARCHTAG
 sleep 2
 
 # Create a trap which emits policy controller logs on failure.


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

Adding support for ppc64le build.

The build architecture is select by setting the ARCH environment variable.
For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
When ARCH is undefined builds defaults to amd64.

I have a Jenkins based Ci running periodically against this repo for ppc64le builds.  
