### PR TITLE
Use libcalico-go's extensions api for egress/cidr api.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9aeab2cd326ce18797d30603ade1c6b7073617247bc557336033423cf2466815
-updated: 2017-09-20T11:13:42.7126042-07:00
+hash: 3288a117938250eb3e49796c5ee5d7e92941822a27fa31fae48edd7389a237c7
+updated: 2017-09-21T18:08:04.224681709-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -150,7 +150,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: a3291af5e19321a381b4ee9c2828c8a179c27bec
+  version: fb0f93099e89eec0379f2b30e21e8427c8dc952d
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -158,6 +158,7 @@ imports:
   - lib/backend/api
   - lib/backend/compat
   - lib/backend/etcd
+  - lib/backend/extensions
   - lib/backend/k8s
   - lib/backend/k8s/custom
   - lib/backend/k8s/resources
@@ -179,7 +180,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/prometheus/client_golang
-  version: 967789050ba94deca04a5e84cce8ad472ce313c1
+  version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,7 +29,7 @@ import:
   - tools/cache
   - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: a3291af5e19321a381b4ee9c2828c8a179c27bec
+  version: fb0f93099e89eec0379f2b30e21e8427c8dc952d
 - package: github.com/projectcalico/felix
   repo: https://github.com/ozdanborne/felix
   version: fv-improvements

--- a/pkg/controllers/networkpolicy/policy_controller.go
+++ b/pkg/controllers/networkpolicy/policy_controller.go
@@ -28,14 +28,14 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	"github.com/projectcalico/libcalico-go/lib/errors"
+	extensions "github.com/projectcalico/libcalico-go/lib/backend/extensions"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
 	uruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/rest"
 )
 
 // PolicyController Implements Controller interface
@@ -46,15 +46,14 @@ type PolicyController struct {
 	informer       cache.Controller
 	calicoObjCache calicocache.ResourceCache
 	calicoClient   *client.Client
-	k8sClientset   *kubernetes.Clientset
 }
 
 // NewPolicyController Constructor for PolicyController
-func NewPolicyController(k8sClientset *kubernetes.Clientset, calicoClient *client.Client) controller.Controller {
+func NewPolicyController(extensionsClient *rest.RESTClient, calicoClient *client.Client) controller.Controller {
 	policyConverter := converter.NewPolicyConverter()
 
 	// Create a NetworkPolicy watcher.
-	listWatcher := cache.NewListWatchFromClient(k8sClientset.Extensions().RESTClient(), "networkpolicies", "", fields.Everything())
+	listWatcher := cache.NewListWatchFromClient(extensionsClient, "networkpolicies", "", fields.Everything())
 
 	// Function returns map of policyName:policy stored by policy controller
 	// in datastore.
@@ -92,7 +91,7 @@ func NewPolicyController(k8sClientset *kubernetes.Clientset, calicoClient *clien
 					// already populated the map in order to minimize work.
 					policyMap = map[string]bool{}
 					for _, i := range items {
-						k := fmt.Sprintf("%s.%s", i.(*v1beta1.NetworkPolicy).Namespace, i.(*v1beta1.NetworkPolicy).Name)
+						k := fmt.Sprintf("%s.%s", i.(*extensions.NetworkPolicy).Namespace, i.(*extensions.NetworkPolicy).Name)
 						policyMap[k] = true
 					}
 				}
@@ -125,7 +124,7 @@ func NewPolicyController(k8sClientset *kubernetes.Clientset, calicoClient *clien
 
 	// Bind the Calico cache to kubernetes cache with the help of an informer. This way we make sure that
 	// whenever the kubernetes cache is updated, changes get reflected in the Calico cache as well.
-	indexer, informer := cache.NewIndexerInformer(listWatcher, &v1beta1.NetworkPolicy{}, 0, cache.ResourceEventHandlerFuncs{
+	indexer, informer := cache.NewIndexerInformer(listWatcher, &extensions.NetworkPolicy{}, 0, cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			log.Debugf("Got ADD event for network policy: %#v", obj)
 			policy, err := policyConverter.Convert(obj)
@@ -166,7 +165,7 @@ func NewPolicyController(k8sClientset *kubernetes.Clientset, calicoClient *clien
 		},
 	}, cache.Indexers{})
 
-	return &PolicyController{indexer, informer, ccache, calicoClient, k8sClientset}
+	return &PolicyController{indexer, informer, ccache, calicoClient}
 }
 
 // Run starts the controller.

--- a/pkg/converter/policy_converter.go
+++ b/pkg/converter/policy_converter.go
@@ -15,13 +15,10 @@
 package converter
 
 import (
-	"fmt"
-
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
 	backendConverter "github.com/projectcalico/libcalico-go/lib/converter"
-	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/tools/cache"
+	extensions "github.com/projectcalico/libcalico-go/lib/backend/extensions"
 )
 
 type policyConverter struct {
@@ -33,17 +30,7 @@ func NewPolicyConverter() Converter {
 }
 
 func (p *policyConverter) Convert(k8sObj interface{}) (interface{}, error) {
-	np, ok := k8sObj.(*v1beta1.NetworkPolicy)
-	if !ok {
-		tombstone, ok := k8sObj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return nil, fmt.Errorf("couldn't get object from tombstone %+v", k8sObj)
-		}
-		np, ok = tombstone.Obj.(*v1beta1.NetworkPolicy)
-		if !ok {
-			return nil, fmt.Errorf("tombstone contained object that is not a NetworkPolicy %+v", k8sObj)
-		}
-	}
+	np := k8sObj.(*extensions.NetworkPolicy)
 
 	var policyConverter k8s.Converter
 	kvpair, err := policyConverter.NetworkPolicyToPolicy(np)

--- a/tests/fv/fv_resiliency_test.go
+++ b/tests/fv/fv_resiliency_test.go
@@ -64,8 +64,6 @@ var _ = Describe("[Resilience] PolicyController", func() {
 		data := fmt.Sprintf(testutils.KubeconfigTemplate, apiserver.IP)
 		kfconfigfile.Write([]byte(data))
 
-		policyController = testutils.RunPolicyController(calicoEtcd.IP, kfconfigfile.Name())
-
 		k8sClient, err = testutils.GetK8sClient(kfconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -96,6 +94,8 @@ var _ = Describe("[Resilience] PolicyController", func() {
 			Body(np).
 			Do().Error()
 		Expect(err).NotTo(HaveOccurred())
+
+		policyController = testutils.RunPolicyController(calicoEtcd.IP, kfconfigfile.Name())
 
 		// Wait for it to appear in Calico's etcd.
 		Eventually(func() *api.Policy {

--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -69,7 +69,7 @@ var _ = Describe("PolicyController", func() {
 		k8sClient, err = testutils.GetK8sClient(kfconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 
-		extensionsClient, err = GetExtensionsClient(kfconfigfile.Name())
+		extensionsClient, err = testutils.GetExtensionsClient(kfconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 
 		// TODO: Use upcoming port checker functions to wait until apiserver is responding to requests.

--- a/tests/fv/fv_test.go
+++ b/tests/fv/fv_test.go
@@ -23,7 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
-	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	extensions "github.com/projectcalico/libcalico-go/lib/backend/extensions"
+
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,6 +34,7 @@ import (
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
+	"k8s.io/client-go/rest"
 )
 
 var _ = Describe("PolicyController", func() {
@@ -42,6 +44,7 @@ var _ = Describe("PolicyController", func() {
 		apiserver        *containers.Container
 		calicoClient     *client.Client
 		k8sClient        *kubernetes.Clientset
+		extensionsClient *rest.RESTClient
 	)
 
 	BeforeEach(func() {
@@ -64,6 +67,9 @@ var _ = Describe("PolicyController", func() {
 		policyController = testutils.RunPolicyController(etcd.IP, kfconfigfile.Name())
 
 		k8sClient, err = testutils.GetK8sClient(kfconfigfile.Name())
+		Expect(err).NotTo(HaveOccurred())
+
+		extensionsClient, err = GetExtensionsClient(kfconfigfile.Name())
 		Expect(err).NotTo(HaveOccurred())
 
 		// TODO: Use upcoming port checker functions to wait until apiserver is responding to requests.
@@ -133,7 +139,7 @@ var _ = Describe("PolicyController", func() {
 					},
 				},
 			}
-			err := k8sClient.Extensions().RESTClient().
+			err := extensionsClient.
 				Post().
 				Resource("networkpolicies").
 				Namespace("default").
@@ -175,6 +181,84 @@ var _ = Describe("PolicyController", func() {
 				p, _ := calicoClient.Policies().Get(api.PolicyMetadata{Name: genPolicyName})
 				return p.Spec.Selector
 			}, time.Second*15, 500*time.Millisecond).Should(Equal("calico/k8s_ns == 'default' && fools == 'gold'"))
+		})
+	})
+
+	Describe("policies", func() {
+		var policyName string
+		var genPolicyName string
+
+		BeforeEach(func() {
+			// Create a Kubernetes NetworkPolicy.
+			policyName = "jelly"
+			genPolicyName = "knp.default.default." + policyName
+			var np *extensions.NetworkPolicy
+			np = &extensions.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      policyName,
+					Namespace: "default",
+				},
+				Spec: extensions.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"fools": "gold",
+						},
+					},
+					Egress: []extensions.NetworkPolicyEgressRule{
+						{
+							To: []extensions.NetworkPolicyPeer{
+								{
+									IPBlock: &extensions.IPBlock{
+										CIDR:   "192.168.0.0/16",
+										Except: []string{"192.168.3.0/24"},
+									},
+								},
+							},
+						},
+					},
+					PolicyTypes: []extensions.PolicyType{extensions.PolicyTypeEgress},
+				},
+			}
+
+			err := extensionsClient.
+				Post().
+				Resource("networkpolicies").
+				Namespace("default").
+				Body(np).
+				Do().Error()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for it to appear in Calico's etcd.
+			Eventually(func() *api.Policy {
+				policy, _ := calicoClient.Policies().Get(api.PolicyMetadata{Name: genPolicyName})
+				return policy
+			}, time.Second*15, 500*time.Millisecond).ShouldNot(BeNil())
+		})
+
+		It("contains correct egress rule", func() {
+			// Verify policy controller indicates correct namespace
+			Eventually(func() string {
+				p, _ := calicoClient.Policies().Get(api.PolicyMetadata{Name: genPolicyName})
+				return p.Spec.Selector
+			}, time.Second*10, 500*time.Millisecond).Should(Equal("calico/k8s_ns == 'default' && fools == 'gold'"))
+
+			// Verify one egress rule
+			Eventually(func() int {
+				p, _ := calicoClient.Policies().Get(api.PolicyMetadata{Name: genPolicyName})
+				return len(p.Spec.EgressRules)
+			}, time.Second*10, 500*time.Millisecond).Should(Equal(1))
+
+			// Verify egress rule's types
+			Eventually(func() []api.PolicyType {
+				p, _ := calicoClient.Policies().Get(api.PolicyMetadata{Name: genPolicyName})
+				return p.Spec.Types
+			}, time.Second*10, 500*time.Millisecond).Should(Equal([]api.PolicyType{"egress"}))
+
+			// Verify no ingress rule
+			Eventually(func() int {
+				p, _ := calicoClient.Policies().Get(api.PolicyMetadata{Name: genPolicyName})
+				return len(p.Spec.IngressRules)
+			}, time.Second*10, 500*time.Millisecond).Should(Equal(0))
 		})
 	})
 })

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -28,11 +28,13 @@ import (
 	"github.com/projectcalico/felix/fv/containers"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/client"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 )
 
-const vK8sApiserver = "v1.7.5"
+const vK8sApiserver = "v1.8.0-beta.1"
 
 const KubeconfigTemplate = `apiVersion: v1
 kind: Config
@@ -95,6 +97,20 @@ func GetK8sClient(kubeconfig string) (*kubernetes.Clientset, error) {
 	}
 
 	return k8sClientset, nil
+}
+
+func GetExtensionsClient(kubeconfig string) (*rest.RESTClient, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes client config: %s", err)
+	}
+
+	extensionsClient, err := k8s.BuildExtensionsClientV1(*config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build extensions client config: %s", err)
+	}
+
+	return extensionsClient, nil
 }
 
 func Stop(c *containers.Container) {


### PR DESCRIPTION
## Description
Use libcalico-go's extensions api for egress/cidr api. STs + UTs are passing.

## Todos
- [x] Tests

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
