### PR TITLE
Handle upgrade with old Felix + new K8s-policy controller

### DIFF
--- a/pkg/converter/policy_converter_test.go
+++ b/pkg/converter/policy_converter_test.go
@@ -98,9 +98,9 @@ var _ = Describe("PolicyConverter", func() {
 			}))
 		})
 
-		// There should be no OutboundRules
+		// There should be one OutboundRule
 		It("should return calico policy with no egress rules", func() {
-			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		// Check that Types field exists and has only 'ingress'
@@ -152,9 +152,9 @@ var _ = Describe("PolicyConverter", func() {
 			Expect(len(pol.(api.Policy).Spec.IngressRules)).To(Equal(0))
 		})
 
-		// There should be no OutboundRules
+		// There should be one OutboundRule
 		It("should return calico policy with no egress rules", func() {
-			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		var policyType api.PolicyType = "ingress"
@@ -203,9 +203,9 @@ var _ = Describe("PolicyConverter", func() {
 			Expect(len(pol.(api.Policy).Spec.IngressRules)).To(Equal(0))
 		})
 
-		// There should be no OutboundRules
+		// There should be one OutboundRule
 		It("should return calico policy with no egress rules", func() {
-			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		var policyType api.PolicyType = "ingress"
@@ -269,9 +269,9 @@ var _ = Describe("PolicyConverter", func() {
 			Expect(pol.(api.Policy).Spec.IngressRules[0].Source.Selector).To(Equal("has(calico/k8s_ns)"))
 		})
 
-		// There should be no OutboundRules
+		// There should be one OutboundRule
 		It("should return calico policy with no egress rules", func() {
-			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(0))
+			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		var policyType api.PolicyType = "ingress"


### PR DESCRIPTION
## Description
Handle upgrade with old Felix + new K8s-policy controller.  

To ease upgrade path, create an allow-all Egress rule, but with Types: Ingress. In the case where there's an older Felix interoperating with a new k8s-policy controller, Felix will ignore the egress rule. When Felix is upgraded, it will ignore the Egress allow-all rule due to Types: Ingress.

## Todos
- [ ] Tests

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
