### PR TITLE
Catch invalid conversion of k8s 1.7 policies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3288a117938250eb3e49796c5ee5d7e92941822a27fa31fae48edd7389a237c7
-updated: 2017-09-21T18:08:04.224681709-07:00
+hash: 6bd98f787617cc287ceb0f42c1ef56b9213390d09108ddc191c3569825f1b5b6
+updated: 2017-09-24T08:48:21.183956462-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -19,6 +19,7 @@ imports:
   - pkg/tlsutil
   - pkg/transport
   - pkg/types
+  - version
 - name: github.com/coreos/go-oidc
   version: be73733bb8cc830d0205609b95d125215f8e9c70
   subpackages:
@@ -27,6 +28,10 @@ imports:
   - key
   - oauth2
   - oidc
+- name: github.com/coreos/go-semver
+  version: 568e959cd89871e61434c1143528d9162da89ef2
+  subpackages:
+  - semver
 - name: github.com/coreos/go-systemd
   version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
@@ -150,7 +155,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: fb0f93099e89eec0379f2b30e21e8427c8dc952d
+  version: 5cabf71a9999834727d83036e986836084e0a13a
   subpackages:
   - lib/api
   - lib/api/unversioned
@@ -180,7 +185,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
+  version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
@@ -188,13 +193,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -202,7 +207,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
+  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
@@ -235,7 +240,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: b6e1ae21643682ce023deb8d152024597b0e9bb4
+  version: 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -276,7 +281,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,7 +29,7 @@ import:
   - tools/cache
   - tools/clientcmd
 - package: github.com/projectcalico/libcalico-go
-  version: fb0f93099e89eec0379f2b30e21e8427c8dc952d
+  version: 5cabf71a9999834727d83036e986836084e0a13a
 - package: github.com/projectcalico/felix
   repo: https://github.com/ozdanborne/felix
   version: fv-improvements

--- a/pkg/converter/policy_converter_test.go
+++ b/pkg/converter/policy_converter_test.go
@@ -17,11 +17,11 @@ package converter_test
 import (
 	"github.com/projectcalico/k8s-policy/pkg/converter"
 	"github.com/projectcalico/libcalico-go/lib/api"
+	extensions "github.com/projectcalico/libcalico-go/lib/backend/extensions"
 	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
-	extensions "github.com/projectcalico/libcalico-go/lib/backend/extensions"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,7 +31,7 @@ var _ = Describe("PolicyConverter", func() {
 
 	npConverter := converter.NewPolicyConverter()
 
-	Context("basic NetworkPolicy", func() {
+	It("basic NetworkPolicy", func() {
 		port80 := intstr.FromInt(80)
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -68,28 +68,28 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Parse the policy.
 		pol, err := npConverter.Convert(&np)
-		It("should not generate a conversion error", func() {
+		By("not generating a conversion error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Assert policy name.
-		It("should return calico policy with expected name", func() {
+		By("returning a calico policy with expected name", func() {
 			Expect(pol.(api.Policy).Metadata.Name).To(Equal("knp.default.default.testPolicy"))
 		})
 
 		// Assert policy order.
-		It("should return calico policy with correct order", func() {
+		By("returning calico policy with correct order", func() {
 			Expect(int(*pol.(api.Policy).Spec.Order)).To(Equal(1000))
 		})
 
 		// Check the selector is correct, and that the matches are sorted.
-		It("should return calico policy with correct selector", func() {
+		By("returning a calico policy with correct selector", func() {
 			Expect(pol.(api.Policy).Spec.Selector).To(Equal(
 				"calico/k8s_ns == 'default' && label == 'value' && label2 == 'value2'"))
 		})
 
 		protoTCP := numorstring.ProtocolFromString("tcp")
-		It("should return calico policy with correct ingress rules", func() {
+		By("returning a calico policy with correct ingress rules", func() {
 			Expect(pol.(api.Policy).Spec.IngressRules).To(ConsistOf(api.Rule{
 				Action:      "allow",
 				Protocol:    &protoTCP, // Defaulted to TCP.
@@ -99,19 +99,19 @@ var _ = Describe("PolicyConverter", func() {
 		})
 
 		// There should be one OutboundRule
-		It("should return calico policy with no egress rules", func() {
+		By("returning a calico policy with no egress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		// Check that Types field exists and has only 'ingress'
 		var policyType api.PolicyType = "ingress"
-		It("should return calico policy with ingress type", func() {
+		By("returning a calico policy with ingress type", func() {
 			Expect(len(pol.(api.Policy).Spec.Types)).To(Equal(1))
 			Expect(pol.(api.Policy).Spec.Types[0]).To(Equal(policyType))
 		})
 	})
 
-	Context("should parse a NetworkPolicy with no rules", func() {
+	It("should parse a NetworkPolicy with no rules", func() {
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
@@ -127,45 +127,45 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Parse the policy.
 		pol, err := npConverter.Convert(&np)
-		It("should not generate a conversion error", func() {
+		By("not generating a conversion error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Assert policy name.
-		It("should return calico policy with expected name", func() {
+		By("returning a calico policy with expected name", func() {
 			Expect(pol.(api.Policy).Metadata.Name).To(Equal("knp.default.default.testPolicy"))
 		})
 
 		// Assert policy order.
-		It("should return calico policy with correct order", func() {
+		By("reteurning a calico policy with correct order", func() {
 			Expect(int(*pol.(api.Policy).Spec.Order)).To(Equal(1000))
 		})
 
 		// Assert selectors
-		It("should return calico policy with correct selector", func() {
+		By("reteurning a calico policy with correct selector", func() {
 			Expect(pol.(api.Policy).Spec.Selector).To(Equal(
 				"calico/k8s_ns == 'default' && label == 'value'"))
 		})
 
 		// There should be no inboundRules
-		It("should return calico policy with no ingress rules", func() {
+		By("reteurning a calico policy with no ingress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.IngressRules)).To(Equal(0))
 		})
 
 		// There should be one OutboundRule
-		It("should return calico policy with no egress rules", func() {
+		By("reteurning a calico policy with no egress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		var policyType api.PolicyType = "ingress"
 		// Check that Types field exists and has only 'ingress'
-		It("should return calico policy with ingress type", func() {
+		By("reteurning a calico policy with ingress type", func() {
 			Expect(len(pol.(api.Policy).Spec.Types)).To(Equal(1))
 			Expect(pol.(api.Policy).Spec.Types[0]).To(Equal(policyType))
 		})
 	})
 
-	Context("should parse a NetworkPolicy with empty podSelector", func() {
+	It("should parse a NetworkPolicy with empty podSelector", func() {
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
@@ -179,44 +179,44 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Parse the policy.
 		pol, err := npConverter.Convert(&np)
-		It("should not generate a conversion error", func() {
+		By("not generating a conversion error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Assert policy name.
-		It("should return calico policy with expected name", func() {
+		By("reteurning a calico policy with expected name", func() {
 			Expect(pol.(api.Policy).Metadata.Name).To(Equal("knp.default.default.testPolicy"))
 		})
 
 		// Assert policy order.
-		It("should return calico policy with correct order", func() {
+		By("reteurning a calico policy with correct order", func() {
 			Expect(int(*pol.(api.Policy).Spec.Order)).To(Equal(1000))
 		})
 
 		// Assert selectors
-		It("should return calico policy with correct selector", func() {
+		By("reteurning a calico policy with correct selector", func() {
 			Expect(pol.(api.Policy).Spec.Selector).To(Equal("calico/k8s_ns == 'default'"))
 		})
 
 		// There should be no inboundRules
-		It("should return calico policy with no ingress rules", func() {
+		By("reteurning a calico policy with no ingress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.IngressRules)).To(Equal(0))
 		})
 
 		// There should be one OutboundRule
-		It("should return calico policy with no egress rules", func() {
+		By("reteurning a calico policy with no egress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		var policyType api.PolicyType = "ingress"
 		// Check that Types field exists and has only 'ingress'
-		It("should return calico policy with ingress type", func() {
+		By("reteurning a calico policy with ingress type", func() {
 			Expect(len(pol.(api.Policy).Spec.Types)).To(Equal(1))
 			Expect(pol.(api.Policy).Spec.Types[0]).To(Equal(policyType))
 		})
 	})
 
-	Context("should parse a NetworkPolicy with an empty namespaceSelector", func() {
+	It("should parse a NetworkPolicy with an empty namespaceSelector", func() {
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testPolicy",
@@ -243,46 +243,46 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Parse the policy.
 		pol, err := npConverter.Convert(&np)
-		It("should not generate a conversion error", func() {
+		By("not generating a conversion error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Assert policy name.
-		It("should return calico policy with expected name", func() {
+		By("reteurning a calico policy with expected name", func() {
 			Expect(pol.(api.Policy).Metadata.Name).To(Equal("knp.default.default.testPolicy"))
 		})
 
 		// Assert policy order.
-		It("should return calico policy with correct order", func() {
+		By("reteurning a calico policy with correct order", func() {
 			Expect(int(*pol.(api.Policy).Spec.Order)).To(Equal(1000))
 		})
 
 		// Assert selectors
-		It("should return calico policy with correct selector", func() {
+		By("reteurning a calico policy with correct selector", func() {
 			Expect(pol.(api.Policy).Spec.Selector).To(Equal(
 				"calico/k8s_ns == 'default' && label == 'value'"))
 		})
 
 		// Assert ingress rules
-		It("should return calico policy with ingress rules", func() {
+		By("reteurning a calico policy with ingress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.IngressRules)).To(Equal(1))
 			Expect(pol.(api.Policy).Spec.IngressRules[0].Source.Selector).To(Equal("has(calico/k8s_ns)"))
 		})
 
 		// There should be one OutboundRule
-		It("should return calico policy with no egress rules", func() {
+		By("reteurning a calico policy with no egress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.EgressRules)).To(Equal(1))
 		})
 
 		var policyType api.PolicyType = "ingress"
 		// Check that Types field exists and has only 'ingress'
-		It("should return calico policy with ingress type", func() {
+		By("reteurning a calico policy with ingress type", func() {
 			Expect(len(pol.(api.Policy).Spec.Types)).To(Equal(1))
 			Expect(pol.(api.Policy).Spec.Types[0]).To(Equal(policyType))
 		})
 	})
 
-	Context("should handle cache.DeletedFinalStateUnknown conversion", func() {
+	It("should handle cache.DeletedFinalStateUnknown conversion", func() {
 		np := cache.DeletedFinalStateUnknown{
 			Key: "cache.DeletedFinalStateUnknown",
 			Obj: &extensions.NetworkPolicy{
@@ -298,39 +298,39 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Parse the policy.
 		pol, err := npConverter.Convert(np)
-		It("should not generate a conversion error", func() {
+		By("not generating a conversion error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Assert policy name.
-		It("should return calico policy with expected name", func() {
+		By("reteurning a calico policy with expected name", func() {
 			Expect(pol.(api.Policy).Metadata.Name).To(Equal("knp.default.default.testPolicy"))
 		})
 	})
 
-	Context("should handle cache.DeletedFinalStateUnknown with non-NetworkPolicy Obj", func() {
+	It("should handle cache.DeletedFinalStateUnknown with non-NetworkPolicy Obj", func() {
 		np := cache.DeletedFinalStateUnknown{
 			Key: "cache.DeletedFinalStateUnknown",
 			Obj: "just a string",
 		}
 
 		_, err := npConverter.Convert(np)
-		It("should generate a conversion error", func() {
+		By("generating a conversion error", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	Context("should handle invalid obj for conversion", func() {
+	It("should handle invalid obj for conversion", func() {
 		np := "anything"
 
 		// Parse the policy.
 		_, err := npConverter.Convert(np)
-		It("should generate a conversion error", func() {
+		By("generating a conversion error", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	Context("GetKey", func() {
+	It("GetKey", func() {
 		policyName := "allow-all"
 		policy := api.Policy{
 			Metadata: api.PolicyMetadata{
@@ -341,12 +341,12 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Get key
 		key := npConverter.GetKey(policy)
-		It("should return name of policy as key", func() {
+		By("returning the name of the policy", func() {
 			Expect(key).To(Equal(policyName))
 		})
 	})
 
-	Context("NetworkPolicy with Egress rule", func() {
+	It("NetworkPolicy with Egress rule", func() {
 		port80 := intstr.FromInt(80)
 		np := extensions.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
@@ -383,44 +383,44 @@ var _ = Describe("PolicyConverter", func() {
 
 		// Parse the policy.
 		pol, err := npConverter.Convert(&np)
-		It("should not generate a conversion error", func() {
+		By("not generating a conversion error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Assert policy name.
-		It("should return calico policy with expected name", func() {
+		By("returning a calico policy with expected name", func() {
 			Expect(pol.(api.Policy).Metadata.Name).To(Equal("knp.default.default.testPolicy"))
 		})
 
 		// Assert policy order.
-		It("should return calico policy with correct order", func() {
+		By("returning a calico policy with correct order", func() {
 			Expect(int(*pol.(api.Policy).Spec.Order)).To(Equal(1000))
 		})
 
 		// Check the selector is correct, and that the matches are sorted.
-		It("should return calico policy with correct selector", func() {
+		By("returning a calico policy with correct selector", func() {
 			Expect(pol.(api.Policy).Spec.Selector).To(Equal(
 				"calico/k8s_ns == 'default' && label == 'value' && label2 == 'value2'"))
 		})
 
 		protoTCP := numorstring.ProtocolFromString("tcp")
-		It("should return calico policy with correct egress rules", func() {
+		By("returning a calico policy with correct egress rules", func() {
 			Expect(pol.(api.Policy).Spec.EgressRules).To(ConsistOf(api.Rule{
-				Action:      "allow",
-				Protocol:    &protoTCP, // Defaulted to TCP.
+				Action:   "allow",
+				Protocol: &protoTCP, // Defaulted to TCP.
 				Destination: api.EntityRule{Selector: "calico/k8s_ns == 'default' && k == 'v' && k2 == 'v2'",
-				                            Ports:    []numorstring.Port{numorstring.SinglePort(80)}},
+					Ports: []numorstring.Port{numorstring.SinglePort(80)}},
 			}))
 		})
 
 		// There should be no InboundRules
-		It("should return calico policy with no egress rules", func() {
+		By("returning a calico policy with no egress rules", func() {
 			Expect(len(pol.(api.Policy).Spec.IngressRules)).To(Equal(0))
 		})
 
 		// Check that Types field exists and has only 'egress'
 		var policyType api.PolicyType = "egress"
-		It("should return calico policy with ingress type", func() {
+		By("returning a calico policy with ingress type", func() {
 			Expect(len(pol.(api.Policy).Spec.Types)).To(Equal(1))
 			Expect(pol.(api.Policy).Spec.Types[0]).To(Equal(policyType))
 		})


### PR DESCRIPTION
## Description

We're not handling policies received from k8s 1.7 properly at the moment.  Namely, those policies don't have a `polciyTypes` field which means libcalico defaults them to `Ingress/Egress`.

The k8s backend really should be catching this and including `Ingress` since k8s 1.7 networkpolicies only affect ingress.

This is just a UT, the fix is in libcalico I think.

This PR also includes some cleaning up of the Context/It/By decorator usage.

CC @tmjd I think this is the failure you're hitting and what's causing the e2e failures.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
