### PR TITLE
Making fv go code arch agnostic.

### DIFF
--- a/tests/testutils/policy_controller_utils.go
+++ b/tests/testutils/policy_controller_utils.go
@@ -19,6 +19,7 @@ package testutils
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/projectcalico/felix/fv/containers"
 )
@@ -32,5 +33,5 @@ func RunPolicyController(etcdIP, kconfigfile string) *containers.Container {
 		"-e", fmt.Sprintf("KUBECONFIG=%s", kconfigfile),
 		"-e", "RECONCILER_PERIOD=10s",
 		"-v", fmt.Sprintf("%s:%s", kconfigfile, kconfigfile),
-		"calico/kube-policy-controller:latest")
+		fmt.Sprintf("%s",os.Getenv("CONTAINER_NAME")))
 }

--- a/tests/testutils/utils.go
+++ b/tests/testutils/utils.go
@@ -21,6 +21,7 @@ package testutils
 import (
 	"fmt"
 	"os/exec"
+	"os"
 
 	. "github.com/onsi/gomega"
 	log "github.com/sirupsen/logrus"
@@ -33,8 +34,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/rest"
 )
-
-const vK8sApiserver = "v1.8.0-beta.1"
 
 const KubeconfigTemplate = `apiVersion: v1
 kind: Config
@@ -53,7 +52,7 @@ current-context: test-context`
 
 func RunK8sApiserver(etcdIp string) *containers.Container {
 	return containers.Run("st-apiserver",
-		fmt.Sprintf("gcr.io/google_containers/hyperkube-amd64:%s", vK8sApiserver),
+		fmt.Sprintf("%s",os.Getenv("HYPERKUBE_IMAGE")),
 		"/hyperkube", "apiserver",
 		"--service-cluster-ip-range=10.101.0.0/16",
 		"--authorization-mode=AlwaysAllow",
@@ -65,7 +64,7 @@ func RunK8sApiserver(etcdIp string) *containers.Container {
 
 func RunEtcd() *containers.Container {
 	return containers.Run("etcd-fv",
-		"quay.io/coreos/etcd",
+		fmt.Sprintf("%s",os.Getenv("ETCD_IMAGE")),
 		"etcd",
 		"--advertise-client-urls", "http://127.0.0.1:2379",
 		"--listen-client-urls", "http://0.0.0.0:2379")


### PR DESCRIPTION
Images used by fv are now defined in the Makefile as environment
variables removing the hard-coding of image names from the fv go code.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
I introduced two new environment variables to point to container images used for the fv tests.  ETCD and HYPERKUBE,  these are passed to tests/fv/fv.test at run time.  This allows arch specific images to be specified the the Makefile.

I verified:
(on x86) make ci
(on ppc64le) ARCH=ppc64le make ci

This change address the issue raised in issue #150 