### PR TITLE
Added missing lock around endpointCache

### DIFF
--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -242,7 +242,9 @@ func (c *PodController) syncToCalico(key string) error {
 	if wepData, exists := c.wepDataCache.Get(key); exists {
 		// Get workloadEndpoint from cache
 		clog := log.WithField("wep", key)
+		c.endpointCache.RLock()
 		endpoint, exists := c.endpointCache.m[key]
+		c.endpointCache.RUnlock()
 		if !exists {
 			// Load endpoint cache.
 			clog.Warnf("No corresponding WorkloadEndpoint in cache, re-loading cache from datastore")


### PR DESCRIPTION
## Description
Previous change 7714b2ef2d2bb2dceef441a836a1e127f31c122e added a mutex to protect the endpointCache and I missed wrapping a usage with the mutex, this fixes that.

## Release Note

```release-note
None required
```
